### PR TITLE
fix: 40個のJava・Android Lint警告を修正

### DIFF
--- a/app/src/main/java/net/t106/sinkerglwallpaper/seekbar_pref.java
+++ b/app/src/main/java/net/t106/sinkerglwallpaper/seekbar_pref.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences.Editor;
 import android.preference.DialogPreference;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
+import java.util.Locale;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -29,7 +30,7 @@ public class seekbar_pref extends DialogPreference{
 		col[1] = sp.getInt("col_G", 50);
 		col[2] = sp.getInt("col_B", 100);
 		col[3] = sp.getInt("col_Alpha", 50);
-		col_tmp = (int[])col.clone();
+		col_tmp = col.clone();
 		setDialogLayoutResource(R.layout.pref_seekbar_pref);
 	}
 	
@@ -50,7 +51,7 @@ public class seekbar_pref extends DialogPreference{
 		SBchange sbc = new SBchange(sb,tv);
 		for(int i=0;i<4;i++)sb[i].setProgress(col[i]);
 		for(int i=0;i<4;i++)sb[i].setOnSeekBarChangeListener(sbc);
-		for(int i=0;i<4;i++)tv[i].setText(String.format("%.2f", col[i]/100.0));
+		for(int i=0;i<4;i++)tv[i].setText(String.format(Locale.US, "%.2f", col[i]/100.0));
 	}
 	
 	@Override
@@ -65,18 +66,18 @@ public class seekbar_pref extends DialogPreference{
 			e.putInt("col_G", col[1]);
 			e.putInt("col_B", col[2]);
 			e.putInt("col_Alpha", col[3]);
-			e.commit();
+			e.apply();
 		}
 		else
 		{
-			col = (int[])col_tmp.clone();
+			col = col_tmp.clone();
 			SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(cxt);
 			Editor e = sp.edit();
 			e.putInt("col_R", col[0]);
 			e.putInt("col_G", col[1]);
 			e.putInt("col_B", col[2]);
 			e.putInt("col_Alpha", col[3]);
-			e.commit();
+			e.apply();
 		}
 	}
 	
@@ -87,9 +88,9 @@ public class seekbar_pref extends DialogPreference{
 	
 	protected void setDefault()
 	{
-		col = (int[])col_default.clone();
+		col = col_default.clone();
 		for(int i=0;i<4;i++)sb[i].setProgress(col[i]);
-		for(int i=0;i<4;i++)tv[i].setText(String.format("%.2f", col[i]/100.0));
+		for(int i=0;i<4;i++)tv[i].setText(String.format(Locale.US, "%.2f", col[i]/100.0));
 	}
 	
 	private class SBchange implements SeekBar.OnSeekBarChangeListener
@@ -110,7 +111,7 @@ public class seekbar_pref extends DialogPreference{
 				if(sb_arr[i].getId() == id)
 				{
 					setColor(i, val);
-					tv[i].setText(String.format("%.2f", val/100.0));
+					tv[i].setText(String.format(Locale.US, "%.2f", val/100.0));
 				}
 		}
 		

--- a/app/src/main/java/net/t106/sinkerglwallpaper/size_change_pref.java
+++ b/app/src/main/java/net/t106/sinkerglwallpaper/size_change_pref.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences.Editor;
 import android.preference.DialogPreference;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
+import java.util.Locale;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -39,7 +40,7 @@ public class size_change_pref extends DialogPreference {
 		sb.setMax(300);
 		sb.setProgress(prog);
 		sb.setOnSeekBarChangeListener(new SBchange());
-		tv.setText(String.format("%.2f", (prog+100)/100.0));
+		tv.setText(String.format(Locale.US, "%.2f", (prog+100)/100.0));
 		btn.setOnClickListener(new btnlis());
 	}
 	
@@ -52,14 +53,14 @@ public class size_change_pref extends DialogPreference {
 			SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(cxt);
 			Editor e = sp.edit();
 			e.putInt("size", prog);
-			e.commit();
+			e.apply();
 		}
 		else
 		{
 			SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(cxt);
 			Editor e = sp.edit();
 			e.putInt("size", tmp_prog);
-			e.commit();
+			e.apply();
 		}
 	}
 	
@@ -67,7 +68,7 @@ public class size_change_pref extends DialogPreference {
 	{
 		sb.setProgress(200);
 		prog = 200;
-		tv.setText(String.format("%.2f", (200+100)/100.0));
+		tv.setText(String.format(Locale.US, "%.2f", (200+100)/100.0));
 	}
 	
 	private class SBchange implements SeekBar.OnSeekBarChangeListener
@@ -75,7 +76,7 @@ public class size_change_pref extends DialogPreference {
 		@Override
 		public void onProgressChanged(SeekBar skbar, int val, boolean flg) 
 		{
-			tv.setText(String.format("%.2f", (val+100)/100.0));
+			tv.setText(String.format(Locale.US, "%.2f", (val+100)/100.0));
 			prog = val;
 		}
 

--- a/app/src/main/res/layout/pref_seekbar_pref.xml
+++ b/app/src/main/res/layout/pref_seekbar_pref.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="fill_parent"
-    android:layout_gravity="left"
-    android:gravity="left"
+    android:layout_gravity="start"
+    android:gravity="start"
     android:orientation="vertical" >
 
     <RelativeLayout
@@ -15,18 +15,18 @@
             android:id="@+id/seekBar1"
             android:layout_width="190dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/textView1"
+            android:layout_toStartOf="@+id/textView1"
             android:layout_weight="1" />
 
         <TextView
             android:id="@+id/textView1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="TextView" />
+            android:text="@string/color_value_placeholder" />
 
     </RelativeLayout>
 
@@ -39,17 +39,17 @@
             android:id="@+id/seekBar2"
             android:layout_width="180dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/textView2" />
+            android:layout_toStartOf="@+id/textView2" />
 
         <TextView
             android:id="@+id/textView2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="TextView" />
+            android:text="@string/color_value_placeholder" />
 
     </RelativeLayout>
 
@@ -62,18 +62,18 @@
             android:id="@+id/seekBar3"
             android:layout_width="190dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/textView3"
+            android:layout_toStartOf="@+id/textView3"
             android:layout_weight="0.15" />
 
         <TextView
             android:id="@+id/textView3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="TextView" />
+            android:text="@string/color_value_placeholder" />
 
     </RelativeLayout>
 
@@ -85,17 +85,17 @@
             android:id="@+id/seekBar4"
             android:layout_width="190dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/textView5" />
+            android:layout_toStartOf="@+id/textView5" />
 
         <TextView
             android:id="@+id/textView5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="TextView" />
+            android:text="@string/color_value_placeholder" />
 
     </RelativeLayout>
 
@@ -109,7 +109,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:text="上からR,G,B,Alpha(透明度)" />
+            android:text="@string/color_description" />
 
         <TextView
             android:id="@+id/textView6"
@@ -117,15 +117,15 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/textView4"
             android:layout_centerHorizontal="true"
-            android:text="透明度はアルファ合成のみ有効" />
+            android:text="@string/alpha_description" />
 
         <Button
             android:id="@+id/button1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignLeft="@+id/textView4"
+            android:layout_alignStart="@+id/textView4"
             android:layout_below="@+id/textView6"
-            android:text="デフォルトに戻す" />
+            android:text="@string/reset_to_default" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/size_change_pref_layout.xml
+++ b/app/src/main/res/layout/size_change_pref_layout.xml
@@ -12,15 +12,15 @@
             android:id="@+id/seekBar1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_toLeftOf="@+id/textView2" />
+            android:layout_toStartOf="@+id/textView2" />
 
         <TextView
             android:id="@+id/textView2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="TextView" />
+            android:text="@string/color_value_placeholder" />
 
     </RelativeLayout>
 
@@ -34,7 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:text="値が大きいほど小さくなります" />
+            android:text="@string/size_description" />
 
     </RelativeLayout>
 
@@ -48,7 +48,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:text="デフォルトに戻す" />
+            android:text="@string/reset_to_default" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="reference">所詮　他愛ない模倣か…</string>
     <string name="name">A THING LEFT BEHIND</string>
     <string name="about">\t^._.^ &lt;にゃーん\n\n\tW A R N I N G\n\n\tAN AWESOME PRAYER\n\tIS\n\tCONFLICT WITH US\n\n&lt;-ABOUT-&gt;\nHellSinker.のメニュー画面、「A THING LEFT BEHIND」を模倣したライブ壁紙です。\n\n&lt;-HOW TO-&gt;\n初期状態でもそれっぽくは表示されてますが、多分微妙に色が違っています。\nメニューからは「合成方法」と「色」を変更出来ますので、好きに使ってください。</string>
+    <string name="color_value_placeholder">0.00</string>
+    <string name="color_description">上からR,G,B,Alpha(透明度)</string>
+    <string name="alpha_description">透明度はアルファ合成のみ有効</string>
+    <string name="reset_to_default">デフォルトに戻す</string>
+    <string name="size_description">値が大きいほど小さくなります</string>
 </resources>


### PR DESCRIPTION
## 概要
追加調査で発見された81個の警告のうち40個を修正しました。

## 修正内容

### 🟢 非常に簡単 (13個)
- **Java redundant cast警告 (3個)**: `int[]`配列の`clone()`の不要キャスト除去
- **ApplySharedPref警告 (4個)**: `commit()`→`apply()`でUIスレッドブロック回避
- **DefaultLocale警告 (6個)**: `String.format()`に`Locale.US`追加で国際化対応

### 🟡 比較的簡単 (27個)
- **HardcodedText警告 (10個)**: XMLのハードコード文字列を`string.xml`に移動
- **RtlHardcoded警告 (17個)**: `Left/Right`属性→`Start/End`属性でRTL対応

## 効果
- 💨 パフォーマンス向上: UIスレッドブロックの減少
- 🌍 国際化対応: ロケール安全な文字列フォーマット
- 🎨 UI/UX改善: RTL言語対応と保守性向上

## 関連Issue
#4

⚠️ 要注意カテゴリの警告は複雑な判断が必要なためスキップしました。

Generated with [Claude Code](https://claude.ai/code)